### PR TITLE
Add openapi-generator to the list

### DIFF
--- a/docs/_data/tools.yaml
+++ b/docs/_data/tools.yaml
@@ -403,6 +403,14 @@
   v2: true
   v3: true
 
+- name: openapi-generator
+  category: sdk
+  language: Java
+  github: https://github.com/OpenAPITools/openapi-generator
+  description: A template-driven engine to generate documentation, API clients and server stubs in different languages by parsing your OpenAPI definition (community-driven fork of swagger-codegen)
+  v2: true
+  v3: true
+
 - name: swagger-node-codegen
   category: sdk
   language: Node.js


### PR DESCRIPTION
[OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) is a community-driven fork of swagger-codegen based on current v2 version `2.4.0-SNAPSHOT`. It is an alternative to swagger-codegen v3 to support OAS2 and OAS3. All generators have been migrated.

More than 40 top contributors and template creators of Swagger Codegen have joined OpenAPI Generator as the founding team members.