### PR TITLE
Add openapi-to-rust to sdk category

### DIFF
--- a/docs/_data/tools.yaml
+++ b/docs/_data/tools.yaml
@@ -7120,3 +7120,11 @@
   category: unclassified
   uuid: 004d1abb-9aa2-4b66-ba9d-a7d5e9e095d0
   downloads: 0
+- name: openapi-to-rust
+  description: Generate strongly-typed Rust structs, async HTTP clients, and SSE streaming clients from OpenAPI 3.1 specs. Supports discriminated unions, anyOf/oneOf, allOf composition, circular $refs, and reconnecting SSE — built for LLM APIs (OpenAI, Anthropic) and similar.
+  github: https://github.com/gpu-cli/openapi-to-rust
+  v3: true
+  language: Rust
+  category: sdk
+  uuid: 2bf0f104-2acd-41ef-9fd4-4fa32e35eb50
+  downloads: 0

--- a/docs/_data/tools.yaml
+++ b/docs/_data/tools.yaml
@@ -3065,6 +3065,14 @@
   category: unclassified
   uuid: 12bf91b6-5b6e-4ae8-ac19-5d5a889ae1c6
   downloads: 0
+- name: openapi-to-rust
+  description: Generate strongly-typed Rust structs, async HTTP clients, and SSE streaming clients from OpenAPI 3.1 specs. Supports discriminated unions, anyOf/oneOf, allOf composition, circular $refs, and reconnecting SSE — built for LLM APIs (OpenAI, Anthropic) and similar.
+  github: https://github.com/gpu-cli/openapi-to-rust
+  v3: true
+  language: Rust
+  category: sdk
+  uuid: 2bf0f104-2acd-41ef-9fd4-4fa32e35eb50
+  downloads: 0
 - name: grpc-gateway
   description: gRPC to JSON proxy generator following the gRPC HTTP spec
   github: https://github.com/grpc-ecosystem/grpc-gateway
@@ -7119,12 +7127,4 @@
   v3: true
   category: unclassified
   uuid: 004d1abb-9aa2-4b66-ba9d-a7d5e9e095d0
-  downloads: 0
-- name: openapi-to-rust
-  description: Generate strongly-typed Rust structs, async HTTP clients, and SSE streaming clients from OpenAPI 3.1 specs. Supports discriminated unions, anyOf/oneOf, allOf composition, circular $refs, and reconnecting SSE — built for LLM APIs (OpenAI, Anthropic) and similar.
-  github: https://github.com/gpu-cli/openapi-to-rust
-  v3: true
-  language: Rust
-  category: sdk
-  uuid: 2bf0f104-2acd-41ef-9fd4-4fa32e35eb50
   downloads: 0


### PR DESCRIPTION
Adds [`openapi-to-rust`](https://github.com/gpu-cli/openapi-to-rust) — a Rust code generator that produces strongly-typed structs, async HTTP clients, and SSE streaming clients from OpenAPI 3.1 specs.

## Why it fills a gap in the existing list

The current Rust entries in `tools.yaml` are mostly OpenAPI 3.0 parsers/serializers (`openapi3-rust`, `keycloak-openapi`). There isn't a Rust **3.1 client generator** with first-class streaming support listed. `openapi-to-rust` covers:

- **OpenAPI 3.1** — objects, arrays, enums, `oneOf`/`anyOf`/`allOf`, discriminated unions
- **HTTP client generation** — async clients with retry, tracing, and auth middleware
- **SSE streaming** — reconnecting Server-Sent Events clients with typed event unions (built for LLM APIs like OpenAI and Anthropic)
- **Smart `\$ref` resolution** — handles circular references and deep nesting
- **TOML config** — declarative alternative to the Rust API
- MIT licensed, on crates.io and docs.rs

## Entry

\`\`\`yaml
- name: openapi-to-rust
  description: Generate strongly-typed Rust structs, async HTTP clients, and SSE streaming clients from OpenAPI 3.1 specs. Supports discriminated unions, anyOf/oneOf, allOf composition, circular \$refs, and reconnecting SSE — built for LLM APIs (OpenAI, Anthropic) and similar.
  github: https://github.com/gpu-cli/openapi-to-rust
  v3: true
  language: Rust
  category: sdk
  uuid: 2bf0f104-2acd-41ef-9fd4-4fa32e35eb50
  downloads: 0
\`\`\`

Format follows the same minimal style used in recent add-tool PRs (#88, #95) — auto-populated fields (stars/forks/etc.) left for the upstream tooling.