### PR TITLE
Add Routebase (OpenAPI-native API lifecycle platform)

### DIFF
--- a/docs/_data/tools.yaml
+++ b/docs/_data/tools.yaml
@@ -1,3 +1,10 @@
+- name: Routebase
+  description: OpenAPI-native platform to design, document, mock, test and monitor APIs from one OpenAPI description, with a built-in MCP server.
+  github: https://routebase.dev/
+  v3: true
+  language: "?"
+  category: editors
+  uuid: 0bee8612-eb6a-4945-8354-52a0b0182fb8
 - name: a127
   description: a127
   github: http://a127.io/


### PR DESCRIPTION
Adds **Routebase** to `docs/_data/tools.yaml`.

Per CONTRIBUTING, this is a PR because Routebase is a commercial SaaS **not hosted on GitHub** (so it can't be picked up via the `openapi3` topic). Entry uses the minimal manual format, matching existing non-GitHub entries.

Routebase is an OpenAPI-native platform: design your OpenAPI description in a visual editor, then generate documentation portals, mock servers, contract tests, and drift monitoring from that one description. It also ships a built-in MCP server. Categorised under `editors` (the visual OpenAPI designer is the primary interaction), though it also spans docs, mocking, and testing.

- Homepage: https://routebase.dev/
- OpenAPI: 3.0 / 3.1