### PR TITLE
Add Gesso (PHP OpenAPI 3.0/3.1/3.2 contract testing library)

### DIFF
--- a/docs/_data/tools.yaml
+++ b/docs/_data/tools.yaml
@@ -7182,3 +7182,13 @@
   category: unclassified
   uuid: 004d1abb-9aa2-4b66-ba9d-a7d5e9e095d0
   downloads: 0
+- github: https://github.com/studio-design/gesso
+  name: Gesso
+  description: >-
+    Gesso — OpenAPI 3.0/3.1/3.2 contract testing for PHP. Framework-independent
+    core with Laravel, Symfony, Pest, and PSR-7 adapters. PHPUnit
+    endpoint-coverage tracking, request/response validation, schema-driven
+    fuzzing, and drift detection.
+  v3: true
+  language: PHP
+  category: validator


### PR DESCRIPTION
Adds [Gesso](https://studio-design.github.io/gesso/), an MIT-licensed PHP library for OpenAPI 3.0/3.1/3.2 contract testing, as a `validator` entry in `docs/_data/tools.yaml`.

The repo carries the `openapi3` and `openapi31` GitHub topics but does not rank into the top 30 topic-search results that `add.js` ingests, so it never gets auto-appended. Opening this PR directly, matching the minimal-entry shape used elsewhere in the file — the nightly metadata build will hydrate stars / forks / license / downloads on the next run.

Highlights:
- OpenAPI 3.0, 3.1, and 3.2 support (dialect-aware JSON Schema).
- Framework-independent core + Laravel, Symfony, Pest, and PSR-7 adapters.
- PHPUnit endpoint-coverage extension at (method, path, status, content-type) granularity.
- Schema-driven fuzzing, enum + schema drift detection.
- MIT licensed, no runtime overhead (test-only).

Source: https://github.com/studio-design/gesso
Docs: https://studio-design.github.io/gesso/
License: MIT
