### PR TITLE
Add apispec (Go, OpenAPI 3.1 from source)

### DIFF
--- a/docs/_data/tools.yaml
+++ b/docs/_data/tools.yaml
@@ -7204,3 +7204,6 @@
   category: unclassified
   uuid: 004d1abb-9aa2-4b66-ba9d-a7d5e9e095d0
   downloads: 0
+- github: https://github.com/ehabterra/apispec
+  v3: true
+  category: unclassified


### PR DESCRIPTION
Adds [ehabterra/apispec](https://github.com/ehabterra/apispec) — generates an OpenAPI 3.1 description from Go source by static analysis, no annotations required. Apache-2.0, 83 stars, actively developed.

The entry matches exactly what `add.js` produces for a newly-tagged repository (`github` / `v3` / `category: unclassified`), so the enrichment step should fill in the rest as normal.

## Why a PR rather than just tagging

I know CONTRIBUTING says tagging with `openapi3` is the preferred route and PRs are for projects not hosted on GitHub. I tagged the repo first — it now carries both `openapi3` and `openapi31` — but the automatic route can't reach it, and I think the reason is worth flagging:

`add.js` calls the REST search endpoint without `per_page` or pagination:

```js
let res = await fetch(`https://api.github.com/search/repositories?q=topic:${topic}`, …);
…
for (let edge of data.items) {
```

That returns GitHub's default **30 results** per topic. Current totals are **1,871** repos tagged `openapi3` and **123** tagged `openapi31`, and because the default sort is best-match (heavily star-weighted), the first 30 for `openapi31` are swagger-ui, redoc, apisix, huma, utoipa and similar. Any project below roughly a thousand stars is structurally unreachable, no matter how correctly it is tagged.

If that's unintended, adding `&per_page=100` plus a pagination loop — or switching to the GraphQL search API with cursor pagination, which is what [`OAI/tools.openapis.org`](https://github.com/OAI/tools.openapis.org/blob/main/lib/data/processors/tagged-repository-processor.js) does for the same topics — would let the automatic route work for everyone else too. Happy to open that as a separate PR if it would be useful; I didn't want to bundle a behaviour change with a listing request.

## About the tool

apispec type-checks a Go module and walks the call graph from each route registration to the handler that actually serves the request, so it resolves handlers behind factories, group closures, middleware chains and mounted sub-routers. It detects Gin, Echo, chi, Fiber, Gorilla Mux and `net/http`, and emits OpenAPI 3.1 only. Output is deterministic, so a committed description can be regenerated in CI and diffed to catch contract drift.